### PR TITLE
[codex] add bottom horse runner

### DIFF
--- a/_includes/horse-runner.html
+++ b/_includes/horse-runner.html
@@ -1,0 +1,72 @@
+<svg viewBox="0 0 400 300" class="bottom-horse-runner__svg" role="img" aria-label="Running horse">
+  <g stroke="rgba(255, 190, 64, 0.18)" stroke-linecap="round">
+    <line class="bottom-horse-runner__line" x1="0" y1="260" x2="150" y2="260" stroke-width="2" />
+    <line class="bottom-horse-runner__line bottom-horse-runner__line--2" x1="0" y1="210" x2="200" y2="210" stroke-width="3" />
+    <line class="bottom-horse-runner__line bottom-horse-runner__line--3" x1="0" y1="100" x2="100" y2="100" stroke-width="1" />
+    <line class="bottom-horse-runner__line bottom-horse-runner__line--4" x1="0" y1="280" x2="300" y2="280" stroke-width="4" stroke="rgba(255,190,64,0.32)" />
+    <circle class="bottom-horse-runner__dust bottom-horse-runner__dust--1" cx="50" cy="270" r="3" />
+    <circle class="bottom-horse-runner__dust bottom-horse-runner__dust--2" cx="80" cy="265" r="4" />
+    <circle class="bottom-horse-runner__dust bottom-horse-runner__dust--3" cx="120" cy="275" r="2" />
+  </g>
+
+  <g transform="translate(61 50) scale(0.64)">
+    <g class="bottom-horse-runner__horse">
+      <g fill="#B8860B">
+        <g class="bottom-horse-runner__back-left-upper">
+          <polygon points="130,130 105,190 145,190" />
+          <g class="bottom-horse-runner__back-left-lower">
+            <polygon points="105,190 145,190 135,245 115,245" />
+            <polygon points="115,245 135,245 140,260 110,260" fill="#222" />
+          </g>
+        </g>
+        <g class="bottom-horse-runner__front-left-upper">
+          <polygon points="240,140 220,190 260,190" />
+          <g class="bottom-horse-runner__front-left-lower">
+            <polygon points="220,190 260,190 250,245 230,245" />
+            <polygon points="230,245 250,245 255,260 225,260" fill="#222" />
+          </g>
+        </g>
+      </g>
+
+      <path class="bottom-horse-runner__tail" d="M 110,120 Q 60,100 30,140 Q 70,150 90,135 Q 100,160 115,130 Z" fill="#FFC125" />
+
+      <g>
+        <polygon points="260,135 220,175 140,165 110,120 170,100 220,100" fill="#FFD700" />
+        <polygon points="250,135 220,165 160,155 170,110 220,110" fill="#FFDF00" />
+        <polygon points="140,165 110,120 140,110 160,155" fill="#DAA520" />
+      </g>
+
+      <g class="bottom-horse-runner__neck-head">
+        <polygon points="220,100 240,40 280,70 260,135" fill="#FFD700" />
+        <polygon points="230,95 245,50 270,75 250,125" fill="#FFDF00" />
+        <polygon points="265,55 310,75 295,100 250,85" fill="#FFC125" />
+        <polygon points="250,85 295,100 270,115" fill="#DAA520" />
+        <polygon points="250,45 260,25 268,48" fill="#DAA520" />
+        <polygon points="242,42 250,20 258,40" fill="#B8860B" />
+        <path d="M 235,40 Q 200,60 210,100 Q 215,70 245,60 Z" fill="#DAA520" />
+        <path d="M 245,35 Q 220,40 225,75 Q 235,50 255,50 Z" fill="#B8860B" />
+      </g>
+
+      <text class="bottom-horse-runner__year" x="180" y="108" text-anchor="middle" dominant-baseline="middle">2026</text>
+
+      <g fill="#FFD700">
+        <g class="bottom-horse-runner__back-right-upper">
+          <polygon points="130,130 105,190 145,190" />
+          <polygon points="130,130 145,190 155,160" fill="#FFDF00" />
+          <g class="bottom-horse-runner__back-right-lower">
+            <polygon points="105,190 145,190 135,245 115,245" />
+            <polygon points="115,245 135,245 140,260 110,260" fill="#111" />
+          </g>
+        </g>
+        <g class="bottom-horse-runner__front-right-upper">
+          <polygon points="240,140 220,190 260,190" />
+          <polygon points="240,140 260,190 270,165" fill="#FFDF00" />
+          <g class="bottom-horse-runner__front-right-lower">
+            <polygon points="220,190 260,190 250,245 230,245" />
+            <polygon points="230,245 250,245 255,260 225,260" fill="#111" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -306,6 +306,11 @@
 
         <hr class="style-two"><br/>
 
+        <!-- 底部彩蛋 -->
+        <div class="bottom-horse-runner" aria-hidden="true">
+          {% include horse-runner.html %}
+        </div>
+
         <!-- 访问数据统计 -->
         <table style="width:40%;border:0px;border-spacing:0px;border-collapse:separate;margin-right:auto;margin-left:auto;">
           <tr>

--- a/style.scss
+++ b/style.scss
@@ -354,6 +354,292 @@ span.highlight {
   background-color: #ffffd0;
 }
 
+.bottom-horse-runner {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 150px;
+  margin: 8px auto 0;
+  overflow: hidden;
+  opacity: 0.82;
+  pointer-events: none;
+}
+
+.bottom-horse-runner__svg {
+  width: min(100%, 516px);
+  height: 100%;
+}
+
+@keyframes bottomHorseGallopBody {
+  0% {
+    transform: translateY(0) rotate(-3deg);
+  }
+  25% {
+    transform: translateY(-18px) rotate(4deg);
+  }
+  50% {
+    transform: translateY(5px) rotate(6deg);
+  }
+  75% {
+    transform: translateY(-5px) rotate(-4deg);
+  }
+  100% {
+    transform: translateY(0) rotate(-3deg);
+  }
+}
+
+@keyframes bottomHorseGallopNeck {
+  0% {
+    transform: rotate(8deg);
+  }
+  25% {
+    transform: rotate(-5deg);
+  }
+  50% {
+    transform: rotate(-10deg);
+  }
+  75% {
+    transform: rotate(5deg);
+  }
+  100% {
+    transform: rotate(8deg);
+  }
+}
+
+@keyframes bottomHorseFrontUpper {
+  0% {
+    transform: rotate(-55deg);
+  }
+  25% {
+    transform: rotate(-10deg);
+  }
+  50% {
+    transform: rotate(20deg);
+  }
+  75% {
+    transform: rotate(45deg);
+  }
+  100% {
+    transform: rotate(-55deg);
+  }
+}
+
+@keyframes bottomHorseFrontLower {
+  0%,
+  25%,
+  100% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(30deg);
+  }
+  75% {
+    transform: rotate(90deg);
+  }
+}
+
+@keyframes bottomHorseBackUpper {
+  0%,
+  100% {
+    transform: rotate(45deg);
+  }
+  25% {
+    transform: rotate(60deg);
+  }
+  50% {
+    transform: rotate(-20deg);
+  }
+  75% {
+    transform: rotate(-40deg);
+  }
+}
+
+@keyframes bottomHorseBackLower {
+  0%,
+  100% {
+    transform: rotate(10deg);
+  }
+  25% {
+    transform: rotate(30deg);
+  }
+  50% {
+    transform: rotate(-50deg);
+  }
+  75% {
+    transform: rotate(-10deg);
+  }
+}
+
+@keyframes bottomHorseTailFly {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(-15deg);
+  }
+  50% {
+    transform: rotate(-5deg);
+  }
+  75% {
+    transform: rotate(10deg);
+  }
+}
+
+@keyframes bottomHorseSpeedLines {
+  0% {
+    transform: translateX(410px);
+    opacity: 0;
+  }
+  12% {
+    opacity: 0.9;
+  }
+  86% {
+    opacity: 0.9;
+  }
+  100% {
+    transform: translateX(-410px);
+    opacity: 0;
+  }
+}
+
+@keyframes bottomHorseCargoBounce {
+  0%,
+  100% {
+    transform: translateY(0) rotate(-5deg);
+  }
+  50% {
+    transform: translateY(-4px) rotate(-8deg);
+  }
+}
+
+.bottom-horse-runner__horse {
+  animation: bottomHorseGallopBody 0.45s infinite cubic-bezier(0.4, 0, 0.2, 1);
+  filter: drop-shadow(0 9px 14px rgba(180, 118, 48, 0.22));
+  transform-origin: 200px 140px;
+  will-change: transform;
+}
+
+.bottom-horse-runner__neck-head {
+  animation: bottomHorseGallopNeck 0.45s infinite ease-in-out;
+  transform-origin: 240px 120px;
+  will-change: transform;
+}
+
+.bottom-horse-runner__tail {
+  animation: bottomHorseTailFly 0.45s infinite ease-in-out;
+  transform-origin: 110px 120px;
+  will-change: transform;
+}
+
+.bottom-horse-runner__front-right-upper,
+.bottom-horse-runner__front-left-upper {
+  animation: bottomHorseFrontUpper 0.45s infinite linear;
+  transform-origin: 240px 140px;
+  will-change: transform;
+}
+
+.bottom-horse-runner__front-right-lower,
+.bottom-horse-runner__front-left-lower {
+  animation: bottomHorseFrontLower 0.45s infinite linear;
+  transform-origin: 240px 190px;
+  will-change: transform;
+}
+
+.bottom-horse-runner__back-right-upper,
+.bottom-horse-runner__back-left-upper {
+  animation: bottomHorseBackUpper 0.45s infinite linear;
+  transform-origin: 130px 130px;
+  will-change: transform;
+}
+
+.bottom-horse-runner__back-right-lower,
+.bottom-horse-runner__back-left-lower {
+  animation: bottomHorseBackLower 0.45s infinite linear;
+  transform-origin: 125px 190px;
+  will-change: transform;
+}
+
+.bottom-horse-runner__front-left-upper,
+.bottom-horse-runner__front-left-lower,
+.bottom-horse-runner__back-left-upper,
+.bottom-horse-runner__back-left-lower {
+  animation-delay: -0.1s;
+}
+
+.bottom-horse-runner__line {
+  animation: bottomHorseSpeedLines 0.3s infinite linear;
+  will-change: transform, opacity;
+}
+
+.bottom-horse-runner__line--2 {
+  animation-duration: 0.2s;
+  animation-delay: 0.1s;
+}
+
+.bottom-horse-runner__line--3 {
+  animation-duration: 0.4s;
+  animation-delay: 0.2s;
+}
+
+.bottom-horse-runner__line--4 {
+  animation-duration: 0.25s;
+  animation-delay: 0.15s;
+}
+
+.bottom-horse-runner__dust {
+  animation: bottomHorseSpeedLines 0.4s infinite linear;
+  fill: #daa520;
+  will-change: transform, opacity;
+}
+
+.bottom-horse-runner__dust--1 {
+  animation-delay: 0.1s;
+  animation-duration: 0.3s;
+}
+
+.bottom-horse-runner__dust--2 {
+  animation-delay: 0.2s;
+  animation-duration: 0.25s;
+}
+
+.bottom-horse-runner__dust--3 {
+  animation-delay: 0.05s;
+  animation-duration: 0.35s;
+}
+
+.bottom-horse-runner__year {
+  animation: bottomHorseCargoBounce 0.45s infinite ease-in-out;
+  fill: #ffe6a0;
+  filter:
+    drop-shadow(2px 3px 3px rgba(0, 0, 0, 0.75))
+    drop-shadow(1px 1px 0 rgba(255, 223, 0, 0.32));
+  font-family: "Arial Black", Impact, sans-serif;
+  font-size: 26px;
+  font-style: italic;
+  transform-origin: 180px 108px;
+  will-change: transform;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bottom-horse-runner__horse,
+  .bottom-horse-runner__neck-head,
+  .bottom-horse-runner__tail,
+  .bottom-horse-runner__front-right-upper,
+  .bottom-horse-runner__front-right-lower,
+  .bottom-horse-runner__back-right-upper,
+  .bottom-horse-runner__back-right-lower,
+  .bottom-horse-runner__front-left-upper,
+  .bottom-horse-runner__front-left-lower,
+  .bottom-horse-runner__back-left-upper,
+  .bottom-horse-runner__back-left-lower,
+  .bottom-horse-runner__line,
+  .bottom-horse-runner__dust,
+  .bottom-horse-runner__year {
+    animation: none !important;
+  }
+}
+
 //@import "highlights";
 //@import "svg-icons";
 
@@ -543,6 +829,15 @@ hr.style-seven:before {
 
   .profile-name-trigger {
     padding: 0;
+  }
+
+  .bottom-horse-runner {
+    height: 110px;
+    margin-top: 0;
+  }
+
+  .bottom-horse-runner__svg {
+    width: min(100%, 396px);
   }
 
   h2 {


### PR DESCRIPTION
## Summary
- Add a bottom-page running horse easter egg using a static SVG include and CSS animations.
- Place the horse before the ClustrMaps script so it renders without waiting on the third-party stats widget.
- Size the runner as a restrained footer accent with responsive desktop/mobile dimensions and reduced-motion support.

## Validation
- `jekyll build`
- Browser checks on desktop and mobile viewports for placement, animation duration, and no horizontal overflow.