### PR TITLE
Add edge-following intro drop-cap orbit

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -70,11 +70,12 @@
               </div>
               <script src="{{ site.baseurl }}/assets/js/name-i-animation.js"></script>
               <p class="intro-bio intro-bio-lead">
-                I graduated from <a href="https://www.seu.edu.cn/">Southeast University</a> with B.S. in GIS.
+                <button class="intro-dropcap-trigger" type="button" aria-label="I — play the introduction orbit animation" disabled>I</button>graduated from <a href="https://www.seu.edu.cn/">Southeast University</a> with B.S. in GIS.
                 I got my Ph.D. degree from <a href="https://mais.ia.ac.cn/">National Laboratory of Pattern Recognition</a>, <a href="https://english.cas.cn/">Chinese Academy of Sciences</a>, supervised by Prof. <a href="https://scholar.google.com/citations?user=Y-nyLGIAAAAJ">Stan Z. Li</a> and Prof. <a href="https://scholar.google.com/citations?user=cuJ3QG8AAAAJ">Zhen Lei</a>, work closely with Associate Prof. <a href="https://scholar.google.com/citations?user=1rbNk5oAAAAJ">Xiangyu Zhu</a>, where I mainly research on <strong>face&vision</strong>, (e.g., <a href="https://github.com/cleardusk/3DDFA">3DDFA</a>, <a href="https://github.com/cleardusk/3DDFA_V2">3DDFA_V2</a>).
                 From July 2021 to March 2025, I worked on <strong>GenAI</strong> (e.g., <a href="https://github.com/KlingAIResearch/LivePortrait">LivePortrait</a>) in <a href="https://github.com/KlingAIResearch">KlingTeam</a>, <a href="https://www.kwai.com/">Kwai Technology</a>.
                 I am currently with <a href="https://www.bytedance.com/">ByteDance</a>, focusing on <strong>multimodal&nbsp;GenAI</strong> (e.g., <a href="https://lance-project.github.io/">Lance</a>).
               </p>
+              <script src="{{ site.baseurl }}/assets/js/intro-dropcap-animation.js"></script>
 
               <!-- Links to social profiles -->
               <p style="text-align:center">

--- a/assets/js/intro-dropcap-animation.js
+++ b/assets/js/intro-dropcap-animation.js
@@ -1,0 +1,387 @@
+(function () {
+  "use strict";
+
+  var DESKTOP_DURATION_MS = 2050;
+  var MOBILE_DURATION_MS = 2200;
+  var MOBILE_BREAKPOINT_PX = 640;
+  var LAUNCH_END = 0.12;
+  var ORBIT_END = 0.9;
+  var TRAIL_LAGS = [0.026, 0.052];
+  var TRAIL_OPACITIES = [0.22, 0.1];
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function easeOutCubic(t) {
+    return 1 - Math.pow(1 - t, 3);
+  }
+
+  function easeInOutCubic(t) {
+    return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+  }
+
+  function easeInOutSine(t) {
+    return (1 - Math.cos(Math.PI * t)) / 2;
+  }
+
+  function easeOutBack(t) {
+    var overshoot = 1.1;
+    return 1 + (overshoot + 1) * Math.pow(t - 1, 3) + overshoot * Math.pow(t - 1, 2);
+  }
+
+  function mix(from, to, t) {
+    return from + (to - from) * t;
+  }
+
+  function cubicPoint(from, control1, control2, to, t) {
+    var inv = 1 - t;
+    return {
+      x: inv * inv * inv * from.x + 3 * inv * inv * t * control1.x +
+        3 * inv * t * t * control2.x + t * t * t * to.x,
+      y: inv * inv * inv * from.y + 3 * inv * inv * t * control1.y +
+        3 * inv * t * t * control2.y + t * t * t * to.y
+    };
+  }
+
+  function rotationForTangent(tangent) {
+    return Math.atan2(tangent.y, tangent.x) * 180 / Math.PI - 90;
+  }
+
+  function unwrapAxisRotation(rotation, previousRotation) {
+    while (rotation - previousRotation > 90) rotation -= 180;
+    while (rotation - previousRotation < -90) rotation += 180;
+    return rotation;
+  }
+
+  function roundedCornerState(centerX, centerY, radius, startAngle, distance) {
+    var angle = startAngle + distance / radius;
+    return {
+      point: {
+        x: centerX + radius * Math.cos(angle),
+        y: centerY + radius * Math.sin(angle)
+      },
+      tangent: {
+        x: -Math.sin(angle),
+        y: Math.cos(angle)
+      }
+    };
+  }
+
+  function orbitState(config, progress) {
+    var radius = config.cornerRadius;
+    var horizontalLength = 2 * (config.radiusX - radius);
+    var verticalLength = 2 * (config.radiusY - radius);
+    var cornerLength = Math.PI * radius / 2;
+    var perimeter = 2 * horizontalLength + 2 * verticalLength + 4 * cornerLength;
+    var distance = (perimeter - cornerLength / 2 + progress * perimeter) % perimeter;
+    var left = config.center.x - config.radiusX;
+    var right = config.center.x + config.radiusX;
+    var top = config.center.y - config.radiusY;
+    var bottom = config.center.y + config.radiusY;
+
+    if (distance < horizontalLength) {
+      return {
+        point: { x: left + radius + distance, y: top },
+        tangent: { x: 1, y: 0 }
+      };
+    }
+    distance -= horizontalLength;
+
+    if (distance < cornerLength) {
+      return roundedCornerState(right - radius, top + radius, radius, -Math.PI / 2, distance);
+    }
+    distance -= cornerLength;
+
+    if (distance < verticalLength) {
+      return {
+        point: { x: right, y: top + radius + distance },
+        tangent: { x: 0, y: 1 }
+      };
+    }
+    distance -= verticalLength;
+
+    if (distance < cornerLength) {
+      return roundedCornerState(right - radius, bottom - radius, radius, 0, distance);
+    }
+    distance -= cornerLength;
+
+    if (distance < horizontalLength) {
+      return {
+        point: { x: right - radius - distance, y: bottom },
+        tangent: { x: -1, y: 0 }
+      };
+    }
+    distance -= horizontalLength;
+
+    if (distance < cornerLength) {
+      return roundedCornerState(left + radius, bottom - radius, radius, Math.PI / 2, distance);
+    }
+    distance -= cornerLength;
+
+    if (distance < verticalLength) {
+      return {
+        point: { x: left, y: bottom - radius - distance },
+        tangent: { x: 0, y: -1 }
+      };
+    }
+    distance -= verticalLength;
+
+    return roundedCornerState(left + radius, top + radius, radius, Math.PI, distance);
+  }
+
+  function pathState(config, progress) {
+    if (progress < LAUNCH_END) {
+      var launchPhase = progress / LAUNCH_END;
+      var launchProgress = easeOutCubic(launchPhase);
+      return {
+        point: cubicPoint(
+          config.origin,
+          config.launchControl1,
+          config.launchControl2,
+          config.orbitStart,
+          launchProgress
+        ),
+        scale: mix(1, config.flightScale, launchProgress),
+        rotate: mix(0, config.orbitStartRotation, easeInOutSine(launchPhase))
+      };
+    }
+
+    if (progress < ORBIT_END) {
+      var orbitProgress = (progress - LAUNCH_END) / (ORBIT_END - LAUNCH_END);
+      var orbit = orbitState(config, orbitProgress);
+      return {
+        point: orbit.point,
+        scale: config.flightScale,
+        rotate: rotationForTangent(orbit.tangent)
+      };
+    }
+
+    var returnPhase = (progress - ORBIT_END) / (1 - ORBIT_END);
+    var returnProgress = easeInOutCubic(returnPhase);
+    return {
+      point: cubicPoint(
+        config.orbitStart,
+        config.returnControl1,
+        config.returnControl2,
+        config.origin,
+        returnProgress
+      ),
+      scale: mix(config.flightScale, 1, easeOutBack(returnPhase)),
+      rotate: mix(config.orbitStartRotation, 0, easeInOutSine(returnPhase))
+    };
+  }
+
+  function setupDropcap(trigger) {
+    if (trigger.getAttribute("data-intro-dropcap-ready") === "true") return;
+
+    var bio = trigger.closest ? trigger.closest(".intro-bio") : trigger.parentElement;
+    var reducedMotion = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)");
+    var mobileViewport = window.matchMedia && window.matchMedia("(max-width: " + MOBILE_BREAKPOINT_PX + "px)");
+    var initialAriaLabel = trigger.getAttribute("aria-label");
+    var animationFrame = null;
+    var feedbackTimer = null;
+    var layers = [];
+    var isRunning = false;
+
+    if (!bio) return;
+    trigger.setAttribute("data-intro-dropcap-ready", "true");
+    trigger.disabled = false;
+
+    function removeLayers() {
+      layers.forEach(function (layer) {
+        layer.element.remove();
+      });
+      layers = [];
+    }
+
+    function finish() {
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+      }
+      removeLayers();
+      trigger.removeAttribute("data-orbit-state");
+      trigger.style.removeProperty("--intro-dropcap-origin-opacity");
+      trigger.setAttribute("aria-label", initialAriaLabel);
+      isRunning = false;
+    }
+
+    function playReducedFeedback() {
+      if (feedbackTimer !== null) window.clearTimeout(feedbackTimer);
+      trigger.classList.remove("is-reduced-feedback");
+      void trigger.offsetWidth;
+      trigger.classList.add("is-reduced-feedback");
+      feedbackTimer = window.setTimeout(function () {
+        trigger.classList.remove("is-reduced-feedback");
+        feedbackTimer = null;
+      }, 260);
+    }
+
+    function createLayer(className, rect, computed, lag, opacity) {
+      var element = document.createElement("span");
+      element.className = "intro-dropcap-orbit " + className;
+      element.textContent = trigger.textContent || "I";
+      element.setAttribute("aria-hidden", "true");
+      element.style.width = rect.width + "px";
+      element.style.height = rect.height + "px";
+      element.style.fontFamily = computed.fontFamily;
+      element.style.fontSize = computed.fontSize;
+      element.style.fontWeight = computed.fontWeight;
+      element.style.lineHeight = computed.lineHeight;
+      bio.appendChild(element);
+      layers.push({ element: element, lag: lag, opacity: opacity, rotation: 0 });
+    }
+
+    function start() {
+      if (isRunning) {
+        finish();
+        return;
+      }
+
+      if (reducedMotion && reducedMotion.matches) {
+        playReducedFeedback();
+        return;
+      }
+
+      var triggerRect = trigger.getBoundingClientRect();
+      var bioRect = bio.getBoundingClientRect();
+      if (!triggerRect.width || !triggerRect.height || !bioRect.width || !bioRect.height) return;
+
+      var isMobile = mobileViewport && mobileViewport.matches;
+      var computed = window.getComputedStyle(trigger);
+      var flightScale = isMobile ? 0.62 : 0.68;
+      var horizontalGap = isMobile ? 5 : 8;
+      var verticalGap = isMobile ? 5 : 7;
+      var edgeReach = isMobile ? 7 : 10;
+      var verticalReach = isMobile ? 10 : 14;
+      var viewportCenterX = bioRect.left + bioRect.width / 2;
+      var center = {
+        x: bioRect.width / 2,
+        y: bioRect.height / 2
+      };
+      var radiusX = Math.min(
+        bioRect.width / 2 + horizontalGap,
+        viewportCenterX - triggerRect.width * flightScale / 2 - 5,
+        window.innerWidth - viewportCenterX - triggerRect.width * flightScale / 2 - 5
+      );
+      var config = {
+        origin: {
+          x: triggerRect.left - bioRect.left + triggerRect.width / 2,
+          y: triggerRect.top - bioRect.top + triggerRect.height / 2
+        },
+        center: center,
+        radiusX: Math.max(32, radiusX),
+        radiusY: Math.max(28, bioRect.height / 2 + verticalGap),
+        flightScale: flightScale
+      };
+      config.cornerRadius = Math.min(
+        isMobile ? 38 : 48,
+        config.radiusX * 0.25,
+        config.radiusY * 0.58
+      );
+      var startState = orbitState(config, 0);
+      config.orbitStart = startState.point;
+      var startTangent = startState.tangent;
+      config.orbitStartRotation = unwrapAxisRotation(rotationForTangent(startTangent), 0);
+      config.launchControl1 = {
+        x: config.origin.x,
+        y: config.origin.y - verticalReach
+      };
+      config.launchControl2 = {
+        x: config.orbitStart.x - startTangent.x * edgeReach,
+        y: config.orbitStart.y - startTangent.y * edgeReach
+      };
+      config.returnControl1 = {
+        x: config.orbitStart.x + startTangent.x * edgeReach,
+        y: config.orbitStart.y + startTangent.y * edgeReach
+      };
+      config.returnControl2 = {
+        x: config.origin.x,
+        y: config.origin.y - verticalReach
+      };
+
+      TRAIL_LAGS.forEach(function (lag, index) {
+        createLayer("intro-dropcap-orbit--trail", triggerRect, computed, lag, TRAIL_OPACITIES[index]);
+      });
+      createLayer("intro-dropcap-orbit--main", triggerRect, computed, 0, 1);
+
+      isRunning = true;
+      trigger.setAttribute("data-orbit-state", "running");
+      trigger.setAttribute("aria-label", "I — stop the introduction orbit animation");
+      var startTime = null;
+      var duration = isMobile ? MOBILE_DURATION_MS : DESKTOP_DURATION_MS;
+
+      function tick(timestamp) {
+        if (startTime === null) startTime = timestamp;
+        var progress = clamp((timestamp - startTime) / duration, 0, 1);
+        var departureProgress = clamp(progress / 0.045, 0, 1);
+        var settleProgress = clamp((progress - 0.925) / 0.075, 0, 1);
+        var originOpacity = progress < 0.045
+          ? mix(1, 0.16, departureProgress)
+          : mix(0.16, 1, settleProgress);
+        trigger.style.setProperty("--intro-dropcap-origin-opacity", originOpacity.toFixed(3));
+
+        layers.forEach(function (layer) {
+          var localProgress = clamp(progress - layer.lag, 0, 1);
+          var state = pathState(config, localProgress);
+          var fadeIn = clamp(localProgress / 0.045, 0, 1);
+          var fadeOut = clamp((1 - progress) / 0.075, 0, 1);
+          layer.rotation = unwrapAxisRotation(state.rotate, layer.rotation);
+          layer.element.style.opacity = (layer.opacity * fadeIn * fadeOut).toFixed(3);
+          layer.element.style.left = (state.point.x - triggerRect.width / 2).toFixed(2) + "px";
+          layer.element.style.top = (state.point.y - triggerRect.height / 2).toFixed(2) + "px";
+          layer.element.style.transform =
+            "rotate(" + layer.rotation.toFixed(2) + "deg) " +
+            "scale(" + state.scale.toFixed(4) + ")";
+        });
+
+        if (progress < 1) {
+          animationFrame = window.requestAnimationFrame(tick);
+        } else {
+          finish();
+        }
+      }
+
+      animationFrame = window.requestAnimationFrame(tick);
+    }
+
+    function cancelOnViewportChange() {
+      if (isRunning) finish();
+    }
+
+    function handleKeydown(event) {
+      if (event.key !== "Escape" || !isRunning) return;
+      event.preventDefault();
+      finish();
+    }
+
+    function handleMotionChange() {
+      if (reducedMotion && reducedMotion.matches && isRunning) finish();
+    }
+
+    trigger.addEventListener("click", start);
+    document.addEventListener("keydown", handleKeydown);
+    document.addEventListener("visibilitychange", cancelOnViewportChange);
+    window.addEventListener("resize", cancelOnViewportChange);
+    window.addEventListener("orientationchange", cancelOnViewportChange);
+
+    if (reducedMotion) {
+      if (typeof reducedMotion.addEventListener === "function") {
+        reducedMotion.addEventListener("change", handleMotionChange);
+      } else if (typeof reducedMotion.addListener === "function") {
+        reducedMotion.addListener(handleMotionChange);
+      }
+    }
+  }
+
+  function init() {
+    Array.prototype.forEach.call(document.querySelectorAll(".intro-dropcap-trigger"), setupDropcap);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/style.scss
+++ b/style.scss
@@ -366,19 +366,96 @@ h1 {
 }
 
 .intro-bio {
+  position: relative;
   margin: 0;
   line-height: 1.4;
   text-wrap: pretty;
 }
 
-.intro-bio-lead::first-letter {
+.intro-dropcap-trigger {
+  appearance: none;
   float: left;
-  margin: 0.08em 0.12em 0 0;
+  position: relative;
+  z-index: 1;
+  margin: 0.08em 0.04em 0 -0.08em;
+  padding: 0 0.08em;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
   color: #111;
   font-family: Georgia, "Times New Roman", serif;
   font-size: 3.4em;
   font-weight: 400;
   line-height: 0.66;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transform-origin: center 62%;
+  transition:
+    color 180ms ease-out,
+    opacity 140ms ease-out,
+    text-shadow 180ms ease-out,
+    transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.intro-dropcap-trigger:disabled {
+  opacity: 1;
+  cursor: default;
+}
+
+.intro-dropcap-trigger:focus-visible {
+  outline: 2px solid #1772d0;
+  outline-offset: 3px;
+}
+
+@media (hover: hover) {
+  .intro-dropcap-trigger:not(:disabled):not([data-orbit-state="running"]):hover {
+    color: #1772d0;
+    text-shadow: 0 5px 15px rgba(23, 114, 208, 0.2);
+    transform: translateY(-2px) rotate(-1deg) scale(1.04);
+  }
+}
+
+.intro-dropcap-trigger:not(:disabled):not([data-orbit-state="running"]):active {
+  color: #1772d0;
+  transform: translateY(1px) scale(0.98);
+}
+
+.intro-dropcap-trigger[data-orbit-state="running"] {
+  color: #1772d0;
+  opacity: var(--intro-dropcap-origin-opacity, 0.16);
+  text-shadow: none;
+  transform: none;
+  transition: none;
+}
+
+.intro-dropcap-trigger.is-reduced-feedback {
+  color: #1772d0;
+}
+
+.intro-dropcap-orbit {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  display: block;
+  margin: 0;
+  padding: 0;
+  color: #1772d0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 400;
+  text-align: center;
+  pointer-events: none;
+  user-select: none;
+  transform-origin: center;
+}
+
+.intro-dropcap-orbit--main {
+  text-shadow: 0 5px 10px rgba(23, 114, 208, 0.2);
+}
+
+.intro-dropcap-orbit--trail {
+  color: #74b9e6;
 }
 
 .profile-name-trigger {
@@ -895,6 +972,12 @@ span.highlight {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .intro-dropcap-trigger {
+    text-shadow: none !important;
+    transform: none !important;
+    transition: color 120ms linear;
+  }
+
   .name-firework {
     display: none !important;
   }
@@ -1113,7 +1196,7 @@ hr.style-seven:before {
     font-size: 1.72em;
   }
 
-  .intro-bio-lead::first-letter {
+  .intro-dropcap-trigger {
     margin-right: 0.1em;
     font-size: 3.2em;
     line-height: 0.72;


### PR DESCRIPTION
## Summary

- turn the introduction drop cap into an accessible interactive control
- animate the letter around the bio on a true rounded-rectangle path with tangent-following rotation and subtle trails
- preserve responsive bounds, cancellation behavior, keyboard focus, and reduced-motion feedback

## Why

The introduction needed a more expressive interaction without disturbing the surrounding typography. A rounded-rectangle perimeter keeps the letter visually attached to the bio edge and avoids cutting across corners, while tangent-following rotation makes each turn feel intentional.

## Validation

- `node --check assets/js/intro-dropcap-animation.js`
- `TZ=UTC bundle exec jekyll build --strict_front_matter`
- Playwright checks at 1440px, 390px, and 320px widths
- verified no horizontal overflow, continuous corner rotation, cleanup on completion/cancel, and reduced-motion behavior
